### PR TITLE
bug fix: show correct branch in semgrep UI

### DIFF
--- a/.github/workflows/semgrep_full_scan.yml
+++ b/.github/workflows/semgrep_full_scan.yml
@@ -38,6 +38,7 @@ jobs:
           git status
           export SEMGREP_REPO_NAME=$SEMGREP_REPO_NAME
           export SEMGREP_REPO_URL=$GIT_URL
+          export SEMGREP_BRANCH=$SEMGREP_BRANCH
           semgrep ci
         env:
           # SEMGREP_REPO_NAME: ${{REPOSITORY_NAME}}
@@ -48,3 +49,4 @@ jobs:
           SEMGREP_REPO_URL: ${{ github.event.client_payload.git_url }}
           SEMGREP_REPO_NAME: ${{ github.event.client_payload.repository_full_name }}
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_BRANCH: ${{ github.event.client_payload.repository_default_branch }}

--- a/.github/workflows/semgrep_scheduled_daily.yml
+++ b/.github/workflows/semgrep_scheduled_daily.yml
@@ -135,7 +135,7 @@ jobs:
           # if df.isin([repo_name]).any().any():
           logging.info('The value "%s" exists in the daily scan list', repo_name)              
           repo_full_name = repo['full_name']
-          repo_branch = repo['default_branch']
+          repo_default_branch = repo['default_branch']
 
           repo_url = repo['clone_url']
           repo_clone_url = repo['clone_url']

--- a/.github/workflows/semgrep_scheduled_daily.yml
+++ b/.github/workflows/semgrep_scheduled_daily.yml
@@ -145,7 +145,7 @@ jobs:
           # Change 'event_type' and 'client_payload' as per your requirements			    
           payload = {
               'event_type': 'zcs-event',
-              'client_payload': { "repository_name": repo_name, "repository_full_name": repo_full_name, "git_url": repo_clone_url }
+              'client_payload': { "repository_name": repo_name, "repository_full_name": repo_full_name, "repository_default_branch": repo_default_branch, "git_url": repo_clone_url }
           }
       
           # Make the POST request

--- a/.github/workflows/semgrep_scheduled_weekly.yml
+++ b/.github/workflows/semgrep_scheduled_weekly.yml
@@ -133,7 +133,7 @@ jobs:
           repo_name = repo['name']
           logging.info('The value "%s" exists in the weekly scan list', repo_name)              
           repo_full_name = repo['full_name']
-          repo_branch = repo['default_branch']
+          repo_default_branch = repo['default_branch']
 
           repo_url = repo['clone_url']
           repo_clone_url = repo['clone_url']

--- a/.github/workflows/semgrep_scheduled_weekly.yml
+++ b/.github/workflows/semgrep_scheduled_weekly.yml
@@ -143,7 +143,7 @@ jobs:
           # Change 'event_type' and 'client_payload' as per your requirements			    
           payload = {
               'event_type': 'zcs-event',
-              'client_payload': { "repository_name": repo_name, "repository_full_name": repo_full_name, "git_url": repo_clone_url }
+              'client_payload': { "repository_name": repo_name, "repository_full_name": repo_full_name, "repository_default_branch": repo_default_branch, "git_url": repo_clone_url }
           }
       
           # Make the POST request

--- a/.github/workflows/semgrep_test.yml
+++ b/.github/workflows/semgrep_test.yml
@@ -132,7 +132,7 @@ jobs:
           # if df.isin([repo_name]).any().any():
           logging.info('The value "%s" exists in the daily scan list', repo_name)              
           repo_full_name = repo['full_name']
-          repo_branch = repo['default_branch']
+          repo_default_branch = repo['default_branch']
 
           repo_url = repo['clone_url']
           repo_clone_url = repo['clone_url']


### PR DESCRIPTION
Added 2 things:

- SEMGREP_BRANCH: ${{ github.event.client_payload.repository_default_branch }} to pass default_branch name
- export SEMGREP_BRANCH=$SEMGREP_BRANCH

Without this, it was showing the default branch for the semgrep-appsec repo
